### PR TITLE
Remove duplicated default tiling shortcuts

### DIFF
--- a/playbooks/keyboard-playbook.yml
+++ b/playbooks/keyboard-playbook.yml
@@ -15,6 +15,13 @@
       when:
         - desktop_env in 'xfce'
 
+    - name: Remove duplicate shortcuts
+      command: xfconf-query -c xfce4-keyboard-shortcuts -p {{ item }}
+      loop: '{{ shortcuts | default(default_removable_shortcuts) }}'
+      failed_when: false
+      when:
+        - desktop_env in 'xfce'
+
     - name: Change keyboard layout
       command: 'xfconf-query -c keyboard-layout -p {{ item.conf }} -n -t string -s {{ item.value }}'
       loop: '{{ layout_configs }}'

--- a/vars/keyboard.yml
+++ b/vars/keyboard.yml
@@ -6,6 +6,12 @@ default_shortcuts:
   - { command: /xfwm4/custom/<Super>Right, action: tile_right_key }
   - { command: /xfwm4/custom/<Super>Up, action: tile_up_key }
 
+default_removable_shortcuts:
+  - /xfwm4/custom/<Super>KP_Down
+  - /xfwm4/custom/<Super>KP_Left
+  - /xfwm4/custom/<Super>KP_Right
+  - /xfwm4/custom/<Super>KP_Up
+
 layout_configs:
   - { conf: /Default/XkbDisable, value: 'false' }
   - { conf: /Default/XkbLayout, value: ',intl' }


### PR DESCRIPTION
XFCE for some reason is now inserting a set of default window-tiling shortcuts under "/xfwm4/custom". They not only seem to not work but, even worse, cause our custom shortcuts to break because there can't be two different shortcuts mapping to the same command, or neither will work.

This PR solves that by adding a new step to the keyboard playbook to remove all of system default shortcuts that conflict with the ones we add by default.