### PR TITLE
Fix ansible warning

### DIFF
--- a/common/install-package-from-third-party.yml
+++ b/common/install-package-from-third-party.yml
@@ -8,7 +8,7 @@
   get_url:
     url: '{{ gpg_key }}'
     dest: '/etc/apt/trusted.gpg.d/{{ gpg_key_name }}'
-  when: '"{{ package }}" not in ansible_facts.packages'
+  when: package not in ansible_facts.packages
 
 - name: Set arch if defined
   set_fact:
@@ -35,7 +35,7 @@
     repo: 'deb [{{arch_var}} signed-by=/etc/apt/trusted.gpg.d/{{ gpg_key_name }}] {{ repository }}'
     state: present
     filename: '{{ filename_var }}'
-  when: '"{{ package }}" not in ansible_facts.packages'
+  when: package not in ansible_facts.packages
 
 - name: Update apt and install package
   become: true


### PR DESCRIPTION
Ansible has been complaining for a while about the use of jinja2 delimiters on conditional statements. The exact message is:
```
[WARNING]: conditional statements should not include jinja2 templating
delimiters such as {{ }} or {% %}. Found: {{ package }} not in
ansible_facts.packages
```

This PR addresses the ones coming from the third party installation task.