### PR TITLE
Update ProtonVPN playbook

### DIFF
--- a/playbooks/protonvpn-playbook.yml
+++ b/playbooks/protonvpn-playbook.yml
@@ -30,6 +30,6 @@
     - name: Install protonvpn
       become: true
       apt:
-        name: protonvpn
+        name: proton-vpn-gtk-app
         state: latest
         update_cache: yes

--- a/vars/protonvpn.yml
+++ b/vars/protonvpn.yml
@@ -1,2 +1,2 @@
 ---
-setup_url: https://repo.protonvpn.com/debian/dists/unstable/main/binary-all/protonvpn-beta-release_1.0.4_all.deb
+setup_url: https://repo.protonvpn.com/debian/dists/unstable/main/binary-all/protonvpn-beta-release_1.0.8_all.deb


### PR DESCRIPTION
There were two issues preventing the protonvpn playbook from working:

1. Proton changed the name of the package from `protonvpn` to `proton-vpn-<ui-toolkit>-app`; and
2. The latest version of their repo setup packaged changed from 1.0.4 to 1.0.8.

This commit fixes #1 by changing the package name to be instalbed to `proton-vpn-gtk-app` and updates the beta package to the latest version.